### PR TITLE
fix: fix the tanstack devtools panel to show in development

### DIFF
--- a/frontend/src/integrations/tanstack-query/devtools.tsx
+++ b/frontend/src/integrations/tanstack-query/devtools.tsx
@@ -1,6 +1,0 @@
-import { ReactQueryDevtoolsPanel } from '@tanstack/react-query-devtools'
-
-export default {
-  name: 'Tanstack Query',
-  render: <ReactQueryDevtoolsPanel />,
-}

--- a/frontend/src/integrations/tanstack-query/layout.tsx
+++ b/frontend/src/integrations/tanstack-query/layout.tsx
@@ -1,0 +1,5 @@
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+
+export default function LayoutAddition() {
+  return <ReactQueryDevtools buttonPosition="bottom-right" />
+}

--- a/frontend/src/integrations/tanstack-query/root-provider.tsx
+++ b/frontend/src/integrations/tanstack-query/root-provider.tsx
@@ -1,19 +1,14 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
+const queryClient = new QueryClient()
+
 export function getContext() {
-  const queryClient = new QueryClient()
   return {
     queryClient,
   }
 }
 
-export function Provider({
-  children,
-  queryClient,
-}: {
-  children: React.ReactNode
-  queryClient: QueryClient
-}) {
+export function Provider({ children }: { children: React.ReactNode }) {
   return (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   )

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -13,11 +13,10 @@ import reportWebVitals from './reportWebVitals.ts'
 
 // Create a new router instance
 
-const TanStackQueryProviderContext = TanStackQueryProvider.getContext()
 const router = createRouter({
   routeTree,
   context: {
-    ...TanStackQueryProviderContext,
+    ...TanStackQueryProvider.getContext(),
   },
   defaultPreload: 'intent',
   scrollRestoration: true,
@@ -39,7 +38,7 @@ if (rootElement && !rootElement.innerHTML) {
   root.render(
     <StrictMode>
       <Auth0Wrapper>
-        <TanStackQueryProvider.Provider {...TanStackQueryProviderContext}>
+        <TanStackQueryProvider.Provider>
           <RouterProvider router={router} />
         </TanStackQueryProvider.Provider>
       </Auth0Wrapper>

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -1,11 +1,9 @@
 import { Outlet, createRootRouteWithContext } from '@tanstack/react-router'
-import { TanStackRouterDevtoolsPanel } from '@tanstack/react-router-devtools'
-import { TanstackDevtools } from '@tanstack/react-devtools'
+import { TanStackRouterDevtools } from '@tanstack/react-router-devtools'
+
+import TanStackQueryLayout from '../integrations/tanstack-query/layout.tsx'
 
 import Sidebar from '../components/Sidebar'
-
-import TanStackQueryDevtools from '../integrations/tanstack-query/devtools'
-
 import type { QueryClient } from '@tanstack/react-query'
 import BottomTabBar from '../components/BottomTabBar'
 
@@ -25,18 +23,10 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
         </main>
         <BottomTabBar />
       </div>
-      <TanstackDevtools
-        config={{
-          position: 'bottom-left',
-        }}
-        plugins={[
-          {
-            name: 'Tanstack Router',
-            render: <TanStackRouterDevtoolsPanel />,
-          },
-          TanStackQueryDevtools,
-        ]}
-      />
+
+      <TanStackRouterDevtools />
+
+      <TanStackQueryLayout />
     </>
   ),
 })


### PR DESCRIPTION
# Fix TanStack Devtools: Not Showing in Dev, Leaking to Production.

## The Problem

Dev: TanStack Router + Query devtools not visible in development
Production: Devtools incorrectly appear on Vercel deployment

Root cause: The template with `bun create vite` uses experimental unified devtools  with custom panels, instead of official standalone components.